### PR TITLE
small feature added - optionally raise errors if env/constants are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ log/
 .bundle/
 .idea/
 pkg/
+.rvmrc

--- a/README.rdoc
+++ b/README.rdoc
@@ -67,6 +67,10 @@ After installing the gem - either using bundler or otherwise - you'll be respons
   AppConstants.environment = "development"
   AppConstants.load!
 
+Optionally you can set raise_error_on_missing which will raise a runtime error 1) during load if the environment doesn't exist and 2) all other times if a constant doesn't exist:
+
+  AppConstants.raise_error_on_missing = true
+  
 == Example
 
 If you have a constants.yml file that looks like this:

--- a/lib/app_constants.rb
+++ b/lib/app_constants.rb
@@ -4,6 +4,7 @@ require 'erb'
 class AppConstants
   @@config_path = Object.const_defined?(:Rails) ? "#{Rails.root}/config/constants.yml" : nil
   @@environment = Object.const_defined?(:Rails) ? Rails.env : 'test'
+  @@raise_error_on_missing = false  # if true this will raise an error if method you seek isn't in constants_hash
   
   def self.config_path=(path)
     @@config_path = path
@@ -13,17 +14,27 @@ class AppConstants
     @@environment = environment
   end  
   
+  def self.raise_error_on_missing=(true_false)
+    @@raise_error_on_missing = true_false
+  end
+  
   def self.method_missing(method, *args)
     @@instance.send(method).is_a?(Hash) ? AppConstants.new(@@instance.constants_hash[method.to_s]) : @@instance.send(method)
   end
 
   def method_missing(method, *args)
+    unless constants_hash.keys.include?(method.to_s) || @@raise_error_on_missing == false
+      raise "Constant #{method.to_s} undefined in yml file. Options are: #{constants_hash.keys.join(", ")}" 
+    end
     constants_hash[method.to_s].nil? ? "" : constants_hash[method.to_s].freeze 
   end
   
   def self.load!
     raise ArgumentError.new("No config file path specified. Use 'AppConstants.config_path = PATH' to set it up") if @@config_path.nil?
     constants_config = YAML::load(pre_process_constants_file)
+    unless constants_config.keys.include?(@@environment) || @@raise_error_on_missing == false
+      raise "Environment #{@@environment} not found in yml file.  Options are: #{constants_config.keys.join(", ")}"
+    end
     constants_hash = constants_config[@@environment] || {}
     @@instance = AppConstants.new(constants_hash)
   end  

--- a/test/app_constants_spec.rb
+++ b/test/app_constants_spec.rb
@@ -17,7 +17,7 @@ describe "AppConstants" do
 
     AppConstants.public_url.should == "development.myawesomeapp.com"
 
-    expect { AppConstants.public_url << "trying something nasty" }.to raise_error(RuntimeError)
+    expect { AppConstants.public_url << "trying something nasty" }.to raise_error(TypeError)
   end
 
   it "should return nil for non-existing environments" do
@@ -36,6 +36,23 @@ describe "AppConstants" do
     AppConstants.max_upload_in_bytes.should == 1048576
   end
 
+  it "should raise a runtime error if raise_error_on_missing is true" do
+    AppConstants.config_path = "#{File.dirname(__FILE__)}/fixtures/constants.yml"
+    AppConstants.raise_error_on_missing = true
+    AppConstants.environment = "development"
+    AppConstants.load!
+    expect { AppConstants.private_url }.to raise_error(RuntimeError)
+    AppConstants.public_url.should == "development.myawesomeapp.com"
+    AppConstants.app_name == "Master of awesomeness"
+    AppConstants.environment = "production"
+    AppConstants.load!
+    expect { AppConstants.private_url }.to raise_error(RuntimeError)
+    AppConstants.public_url.should == "www.myawesomeapp.com"
+    AppConstants.app_name == "Master of awesomeness"
+    AppConstants.environment = "playpen"
+    expect { AppConstants.load! }.to raise_error(RuntimeError)
+  end
+  
   describe "#load!" do
 
     before(:each) do


### PR DESCRIPTION
Adding .rvmrc to .gitignore, adding ability to raise errors if env/constants are missing, updating README to reflect changes.  Updating tests.

I had to change one test in app_constants_spec.rb - line 20 - it was throwing a TypeError, not a RuntimeError (before I made changes).  

This addition shouldn't effect default code.  Unless you set this value nothing should change (which was reflected in tests).
