### PR TITLE
Allow for inspection of environment and config_path.

### DIFF
--- a/lib/app_constants.rb
+++ b/lib/app_constants.rb
@@ -5,11 +5,19 @@ class AppConstants
   @@config_path = Object.const_defined?(:Rails) ? "#{Rails.root}/config/constants.yml" : nil
   @@environment = Object.const_defined?(:Rails) ? Rails.env : 'test'
   @@raise_error_on_missing = false  # if true this will raise an error if method you seek isn't in constants_hash
-  
+
+  def self.config_path
+    @@config_path
+  end
+
   def self.config_path=(path)
     @@config_path = path
   end
-  
+
+  def self.environment
+    @@environment
+  end
+
   def self.environment=(environment)
     @@environment = environment
   end  

--- a/test/app_constants_spec.rb
+++ b/test/app_constants_spec.rb
@@ -64,6 +64,18 @@ describe "AppConstants" do
     AppConstants.delayed_jobs.timeouts.default.should == 300
     AppConstants.very.deep.nesting.level == true
   end
+
+  it "should allow for inspection of config_path" do
+    expected_path = "#{File.dirname(__FILE__)}/fixtures/constants.yml"
+    AppConstants.config_path = expected_path
+    AppConstants.config_path.should == expected_path
+  end
+
+  it "should allow for inspection of environment" do
+    expected_env = "some-environment-#{rand(999)}"
+    AppConstants.environment = expected_env
+    AppConstants.environment.should == expected_env
+  end
   
   describe "#load!" do
 


### PR DESCRIPTION
As part of some tests I have, I need to be able to temporarily swap out the environment and config_path, eg.

```
def modify_app_constants(&block)
  old_config_path = AppConstants.config_path
  old_environment = AppConstants.environment
  yield if block_given?
  AppConstants.config_path = old_config_path
  AppConstants.environment = old_environment
  AppConstants.load!
end
```

There's no way to do this at present; this pull requests adds a couple of attribute readers (with tests) for this purpose.
