### PR TITLE
Adding a convenience method for Rspec users

### DIFF
--- a/lib/app_constants.rb
+++ b/lib/app_constants.rb
@@ -67,6 +67,10 @@ class AppConstants
     template = File.open(@@config_path).read
     ERB.new(template).result
   end
+
+  def self.respond_to_missing?(method, private = false)
+    @@instance.constants_hash.keys.include?(method.to_s)
+  end
   
   attr_reader :constants_hash
   def initialize(constants_hash)

--- a/test/app_constants_spec.rb
+++ b/test/app_constants_spec.rb
@@ -76,6 +76,16 @@ describe "AppConstants" do
     AppConstants.environment = expected_env
     AppConstants.environment.should == expected_env
   end
+
+  it "should define respond_to_missing? for easier testing" do
+    AppConstants.config_path = "#{File.dirname(__FILE__)}/fixtures/constants.yml"
+    AppConstants.raise_error_on_missing = false
+    AppConstants.environment = "development"
+    AppConstants.load!
+
+    AppConstants.respond_to_missing?(:app_name).should == true
+    AppConstants.respond_to_missing?(:nope).should == false
+  end
   
   describe "#load!" do
 


### PR DESCRIPTION
When testing against dynamic classes (AppConstant) Rspec will raise an
exception if you try to allow() or expect() on a class that does not
respond to the method. Rspec uses self.respond_to_missing? as an
underlying method to determine whether the stub is wrapping a real
method or not.

For example without the `self.respond_to_missing?` method:
```
     Failure/Error: allow(AppConstants).to receive(:app_name).and_return("My App")                                            
       AppConstants does not implement: app_name  
```

More information at
https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles/dynamic-classes